### PR TITLE
[DPE-6078] add security manifest

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,6 +62,8 @@ apps:
 
 parts:
   valkey:
+    build-environment:
+      - SNAPCRAFT_BUILD_INFO: 1
     plugin: make
     source: https://github.com/valkey-io/valkey/archive/refs/tags/7.2.5.tar.gz
     override-build: |


### PR DESCRIPTION
This PR adds a `manifest.yaml` to the snap to allow for vulnerability scanning by the security team. The files is generated during the `snapcraft pack` process and is stored to the snap in `/snap/charmed-valkey/current/snap/`.