### PR TITLE
[DPE-6078] Build from deb packages, update to 7.2.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap_without_cache.yaml@v2
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v24.0.4
 
   test:
     name: Test Snap

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,11 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.build.outputs.artifact-name }}
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          merge-multiple: true
       - id: get-snap-name
         run: echo "SNAP_FILE=$(ls *.snap)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,13 +17,13 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v12.6.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v24.0.4
 
   release:
     name: Release snap
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v12.6.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v24.0.4
     with:
       channel: latest/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,4 +64,6 @@ parts:
   valkey:
     plugin: nil
     stage-packages:
-      - valkey
+      - valkey-server
+      - valkey-sentinel
+      - valkey-tools

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-valkey # you probably want to 'snapcraft register <name>'
-base: core22 # the base snap is the execution environment for this snap
-version: '7.2.5' # just for humans, typically '1.2+git' or '1.3.2'
+base: core24 # the base snap is the execution environment for this snap
+version: '7.2.7' # just for humans, typically '1.2+git' or '1.3.2'
 summary: 'Valkey: open source, in memory datastore as a snap' # 79 char long summary
 description: |
   Valkey is an open source, in memory datastore released under 
@@ -62,13 +62,6 @@ apps:
 
 parts:
   valkey:
-    build-environment:
-      - SNAPCRAFT_BUILD_INFO: 1
-    plugin: make
-    source: https://github.com/valkey-io/valkey/archive/refs/tags/7.2.5.tar.gz
-    override-build: |
-      mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr
-      make BUILD_TLS=yes
-      PREFIX=${SNAPCRAFT_PART_INSTALL}/usr make BUILD_TLS=yes install
-    build-packages:
-      - libssl-dev
+    plugin: nil
+    stage-packages:
+      - valkey


### PR DESCRIPTION
In order to publish the Valkey rock in Dockerhub, we need to adjust the snap to make use of the Debian packages available in Ubuntu 24.04 instead of building from source. This is important to get support from the Security team for the published image in Dockerhub.

With this PR:
- the snap build recipe (`snapcraft.yaml`) is adjusted to use the deb packages
- the underlying base image is updated to core24
- the valkey version is updated to 7.2.7