### PR TITLE
[DPE-9011] Build snap for Valkey 9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,16 +21,15 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
-      - id: get-snap-name
-        run: echo "SNAP_FILE=$(ls *.snap)" >> $GITHUB_OUTPUT
 
       - name: Install snap file
         run: |
-          sudo snap install ${{ steps.get-snap-name.outputs.SNAP_FILE }} --dangerous
+          sudo snap install --dangerous charmed-valkey*.snap
 
       - name: Start snap service
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v24.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v40.0.2
 
   test:
     name: Test Snap

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # to avoid "cannot install snap base "core26": no snap revision available as specified"
+      # can be removed once core26 is stable
+      - name: Install dependencies
+        run: |
+          sudo snap install core26 --edge
+
       - uses: actions/download-artifact@v4
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,13 +17,13 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v24.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v40.0.2
 
   release:
     name: Release snap
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v24.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v40.0.0
     with:
       channel: latest/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,9 @@ jobs:
     name: Release snap
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v40.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v40.0.2
     with:
-      channel: latest/edge
+      channel: 9/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     secrets:
       snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,11 +1,11 @@
 name: charmed-valkey # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
-version: '7.2.11' # just for humans, typically '1.2+git' or '1.3.2'
+version: '9.0.1' # just for humans, typically '1.2+git' or '1.3.2'
 summary: 'Valkey: open source, in memory datastore as a snap' # 79 char long summary
 description: |
-  Valkey is an open source, in memory datastore released under 
-  the BSD-3 Clause License. It is a continuation of the work 
-  that was being done on Redis 7.2.4.
+  A flexible distributed key-value database that is optimized 
+  for caching and other realtime workloads. Valkey is an open 
+  source, in memory datastore released under the BSD-3 Clause License.
 
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
@@ -62,8 +62,13 @@ apps:
 
 parts:
   valkey:
-    plugin: nil
-    stage-packages:
-      - valkey-server
-      - valkey-sentinel
-      - valkey-tools
+    plugin: make
+    source: https://git.launchpad.net/valkey
+    source-type: git
+    source-tag: lp-9.0.1
+    override-build: |
+      mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr
+      make BUILD_TLS=yes
+      PREFIX=${SNAPCRAFT_PART_INSTALL}/usr make BUILD_TLS=yes install
+    build-packages:
+      - libssl-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,9 @@ description: |
 
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
+platforms:
+  amd64:
+  arm64:
 
 apps:
   server:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
-name: charmed-valkey # you probably want to 'snapcraft register <name>'
-base: core24 # the base snap is the execution environment for this snap
-version: '9.0.1' # just for humans, typically '1.2+git' or '1.3.2'
+name: charmed-valkey
+base: core26
+build-base: devel # can be removed once 26.04 was released to `stable`
+version: '9.0.1'
 summary: 'Valkey: open source, in memory datastore as a snap' # 79 char long summary
 description: |
   A flexible distributed key-value database that is optimized 


### PR DESCRIPTION
This PR adds a Valkey 9 build based on `core26`. It builds from source (mirrored into launchpad, see [Wiki](https://github.com/canonical/charmed-valkey-snap/wiki/Release-workflow)).

The build base is still in `devel`, this must be adjusted after 26.04 has been released.

From now on, we will have two separate branches in this repository:
- `7-24.04` for maintaining the Valkey 7 version we publish via OCI factory in [Dockerhub](https://hub.docker.com/r/ubuntu/valkey)
- `9-26.04` for maintaining Valkey 9 for our charmed operator