### PR TITLE
[DPE-9251] Build from sourcecraft

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v41.1.0
     with:
       lxd-snap-channel: 5.21/candidate
+    runs-on:
+      [ self-hosted-linux-amd64-noble-private-endpoint-medium ]
 
   test:
     name: Test Snap

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v41.1.0
 
   test:
     name: Test Snap

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ jobs:
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v41.1.0
+    with:
+      lxd-snap-channel: 5.21/candidate
 
   test:
     name: Test Snap

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,13 +17,13 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v41.1.0
 
   release:
     name: Release snap
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v41.1.0
     with:
       channel: 9/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,9 +67,8 @@ apps:
 parts:
   valkey:
     plugin: make
-    source: https://git.launchpad.net/valkey
-    source-type: git
-    source-tag: lp-9.0.1
+    source: sourcecraft:valkey
+    source-channel: 9.0-24.04/edge
     override-build: |
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr
       make BUILD_TLS=yes


### PR DESCRIPTION
Switch from building the snap from launchpad source to building it from sourcecraft source.

_Currently marked as draft because of an issue in lxd with core26 builds, waiting for the fix to be promoted to stable_