### PR TITLE
[DPE-9399]: Add sentinel daemon

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,3 +45,11 @@ jobs:
       - name: Run valkey cli
         run: |
           charmed-valkey.cli info
+
+      - name: Run valkey sentinel
+        run: |
+          sudo snap start charmed-valkey.sentinel
+          sleep 5
+      - name: Run valkey sentinel info
+        run: |
+          charmed-valkey.cli -p 26379 sentinel masters

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -8,6 +8,7 @@ mkdir -p "${CONF}"
 
 # add default config file
 cp "${SNAP}"/etc/valkey.conf "${CONF}"/
+cp "${SNAP}"/etc/sentinel.conf "${CONF}"/
 
 # If we just created the directories, we set up permissions
 if [ stat -c '%u' "${DATA}" == 0 ]; then

--- a/snap/local/start_sentinel.sh
+++ b/snap/local/start_sentinel.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# For security measures, daemons should not be run as sudo. Execute valkey as the non-sudo user: snap-daemon.
+exec "${SNAP}"/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- "${SNAP}"/usr/bin/valkey-sentinel "${SNAP_DATA}"/etc/charmed-valkey/sentinel.conf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,8 +1,8 @@
 name: charmed-valkey
 base: core26
 build-base: devel # can be removed once 26.04 was released to `stable`
-version: '9.0.1'
-summary: 'Valkey: open source, in memory datastore as a snap' # 79 char long summary
+version: "9.0.1"
+summary: "Valkey: open source, in memory datastore as a snap" # 79 char long summary
 description: |
   A flexible distributed key-value database that is optimized 
   for caching and other realtime workloads. Valkey is an open 
@@ -60,7 +60,11 @@ apps:
       - network-observe
       - home
   sentinel:
-    command: usr/bin/valkey-sentinel
+    command: start_sentinel.sh
+    daemon: simple
+    install-mode: disable
+    restart-condition: always
+    restart-delay: 20s
     environment:
       LANG: C.UTF-8
     plugs:
@@ -81,6 +85,7 @@ parts:
       make BUILD_TLS=yes
       PREFIX=${SNAPCRAFT_PART_INSTALL}/usr make BUILD_TLS=yes install
       cp valkey.conf ${SNAPCRAFT_PART_INSTALL}/etc/
+      cp sentinel.conf ${SNAPCRAFT_PART_INSTALL}/etc/
     build-packages:
       - libssl-dev
     stage-packages:


### PR DESCRIPTION
This pull request adds support for running Valkey Sentinel as part of the snap package. It introduces a dedicated startup script for Sentinel, ensures the correct configuration file is included and installed, and updates the CI workflow to test the Sentinel functionality. Additionally, it makes some minor formatting improvements to the snap metadata.

**Valkey Sentinel support:**

* Added a `start_sentinel.sh` script to securely launch Valkey Sentinel as the `snap_daemon` user, improving security by avoiding running as root.
* Updated the `sentinel` app definition in `snap/snapcraft.yaml` to use `start_sentinel.sh`, configure it as a simple daemon, and set appropriate install and restart behaviors.
* Ensured `sentinel.conf` is included during the build and copied to the correct configuration location during install. [[1]](diffhunk://#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5R88) [[2]](diffhunk://#diff-e58b9a041906b37e03356984486699655b2d559fa8dc4d95b340a3b5be7a9a42R11)

**Continuous Integration improvements:**

* Extended the CI workflow to start the Sentinel daemon and run a basic Sentinel command to verify its operation.

**Minor improvements:**

* Standardized YAML formatting for version and summary fields in `snap/snapcraft.yaml`.