### PR TITLE
[DPE-9327] allow storage reuse

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -19,5 +19,5 @@ if [ stat -c '%u' "${CONF}" == 0 ]; then
     chmod -R 770 "${SNAP_DATA}"
 fi
 
-chown -R 584788:584788 "${SNAP_COMMON}"/*
-chown -R 584788:584788 "${SNAP_DATA}"/*
+chown -R 584788:root "${SNAP_COMMON}"/*
+chown -R 584788:root "${SNAP_DATA}"/*


### PR DESCRIPTION
Group ownership must be set for `root` to allow storage reuse, otherwise installation will fail if storage path is already existing.

Example:
```
$ juju deploy ./valkey_ubuntu@24.04-amd64.charm --trust --storage data=data-storage,2G,1 
...
error: cannot perform the following tasks:
- Copy snap "charmed-valkey" data (unlinkat /var/snap/charmed-valkey/common/var/lib/charmed-valkey: device or resource busy)
- Run install hook of "charmed-valkey" snap if present (run hook "install": 
-----
/snap/charmed-valkey/16/meta/hooks/install: 14: [: stat: unexpected operator
/snap/charmed-valkey/16/meta/hooks/install: 18: [: stat: unexpected operator
chown: cannot access '/var/snap/charmed-valkey/common/var/lib/charmed-valkey': Permission denied
-----)
```

Successfully tested on the vm charm with locally installed snap in dev-mode.