### PR TITLE
patch: upgrade 9.1.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: charmed-valkey
 base: core26
 build-base: devel # can be removed once 26.04 was released to `stable`
-version: "9.0.1"
+version: "9.1.0"
 summary: "Valkey: open source, in memory datastore as a snap" # 79 char long summary
 description: |
   A flexible distributed key-value database that is optimized 
@@ -78,7 +78,7 @@ parts:
     plugin: make
     source: https://git.launchpad.net/valkey
     source-type: git
-    source-tag: lp-9.0.1
+    source-tag: lp-9.1.0
     override-build: |
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr
       mkdir -p ${SNAPCRAFT_PART_INSTALL}/etc


### PR DESCRIPTION
This pull request updates the snap packaging for Valkey to the latest upstream release, ensuring that the snap delivers the most recent version of the software. The main changes are version bumps in the snap metadata and the build configuration.

Version updates:

* Updated the `version` field in `snap/snapcraft.yaml` from "9.0.1" to "9.1.0" to reflect the new upstream release.
* Changed the `source-tag` for the Valkey part in `snap/snapcraft.yaml` from `lp-9.0.1` to `lp-9.1.0` to build from the correct upstream tag.