### PR TITLE
chore: update Valkey 7 to 7.2.12

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-valkey # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
-version: '7.2.11' # just for humans, typically '1.2+git' or '1.3.2'
+version: '7.2.12' # just for humans, typically '1.2+git' or '1.3.2'
 summary: 'Valkey: open source, in memory datastore as a snap' # 79 char long summary
 description: |
   Valkey is an open source, in memory datastore released under 


### PR DESCRIPTION
Update Valkey 7 to `7.2.12` to update security issues.