### PR TITLE
[DPE-10645] Fix storage paths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Add ldap-module config
         run: |
           ldap_module="/snap/charmed-valkey/current/usr/lib/libvalkey_ldap.so"
-          config_file="/var/snap/charmed-valkey/current/etc/charmed-valkey/valkey.conf"
+          config_file="/var/snap/charmed-valkey/current/etc/valkey/valkey.conf"
           echo "loadmodule ${ldap_module}" | sudo tee -a ${config_file}
 
       - name: Start snap service

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,8 +1,8 @@
 #!/bin/sh -e
 
 # create Valkey's working directory
-DATA="${SNAP_COMMON}"/var/lib/charmed-valkey
-CONF="${SNAP_DATA}"/etc/charmed-valkey
+DATA="${SNAP_COMMON}"/var/lib/valkey
+CONF="${SNAP_DATA}"/etc/valkey
 mkdir -p "${DATA}"
 mkdir -p "${CONF}"
 

--- a/snap/local/start_sentinel.sh
+++ b/snap/local/start_sentinel.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # For security measures, daemons should not be run as sudo. Execute valkey as the non-sudo user: snap-daemon.
-exec "${SNAP}"/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- "${SNAP}"/usr/bin/valkey-sentinel "${SNAP_DATA}"/etc/charmed-valkey/sentinel.conf
+exec "${SNAP}"/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- "${SNAP}"/usr/bin/valkey-sentinel "${SNAP_DATA}"/etc/valkey/sentinel.conf

--- a/snap/local/start_valkey.sh
+++ b/snap/local/start_valkey.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # For security measures, daemons should not be run as sudo. Execute valkey as the non-sudo user: snap-daemon.
-exec "${SNAP}"/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- "${SNAP}"/usr/bin/valkey-server "${SNAP_DATA}"/etc/charmed-valkey/valkey.conf
+exec "${SNAP}"/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- "${SNAP}"/usr/bin/valkey-server "${SNAP_DATA}"/etc/valkey/valkey.conf


### PR DESCRIPTION
According to DA277, the subdirectories within the SNAP directories are supposed to be called `valkey` instead of `charmed-valkey`. This PR adjusts the paths that are installed.